### PR TITLE
Tests support django 1.10 && Shallow copy field

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -18,6 +18,13 @@ if django.VERSION[:2] < (1, 5):
         }
     }
 
+if django.VERSION[:2] >= (1, 10):
+    opts['TEMPLATES'] = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        },
+    ]
+
 settings.configure(**opts)
 
 if django.VERSION[:2] >= (1, 7):

--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -1,5 +1,6 @@
 import re
 import types
+from copy import copy
 from django.template import Library, Node, Variable, TemplateSyntaxError
 register = Library()
 
@@ -18,6 +19,8 @@ def _process_field_attributes(field, attr, process):
     params = attr.split(':', 1)
     attribute = params[0]
     value = params[1] if len(params) == 2 else ''
+
+    field = copy(field)
 
     # decorate field.as_widget method with updated attributes
     old_as_widget = field.as_widget

--- a/widget_tweaks/tests.py
+++ b/widget_tweaks/tests.py
@@ -318,6 +318,48 @@ class RenderFieldTagFieldReuseTest(TestCase):
         self.assertEqual(res.count("class0"), 3)
         self.assertEqual(res.count("bar"), 1)
 
+    def test_field_double_rendering_id(self):
+        res = render_form(
+            '{{ form.simple }}'
+            '{% render_field form.simple id="id_1" %}'
+            '{% render_field form.simple id="id_2" %}'
+        )
+        self.assertEqual(res.count("id_1"), 1)
+        self.assertEqual(res.count("id_2"), 1)
+
+    def test_field_double_rendering_id_name(self):
+        res = render_form(
+            '{{ form.simple }}'
+            '{% render_field form.simple id="id_1" name="n_1" %}'
+            '{% render_field form.simple id="id_2" name="n_2" %}'
+        )
+        self.assertEqual(res.count("id_1"), 1)
+        self.assertEqual(res.count("id_2"), 1)
+        self.assertEqual(res.count("n_1"), 1)
+        self.assertEqual(res.count("n_2"), 1)
+
+    def test_field_double_rendering_id_class(self):
+        res = render_form(
+            '{{ form.simple }}'
+            '{% render_field form.simple id="id_1" class="c_1" %}'
+            '{% render_field form.simple id="id_2" class="c_2" %}'
+        )
+        self.assertEqual(res.count("id_1"), 1)
+        self.assertEqual(res.count("id_2"), 1)
+        self.assertEqual(res.count("c_1"), 1)
+        self.assertEqual(res.count("c_2"), 1)
+
+    def test_field_double_rendering_name_class(self):
+        res = render_form(
+            '{{ form.simple }}'
+            '{% render_field form.simple name="n_1" class="c_1" %}'
+            '{% render_field form.simple name="n_2" class="c_2" %}'
+        )
+        self.assertEqual(res.count("n_1"), 1)
+        self.assertEqual(res.count("n_2"), 1)
+        self.assertEqual(res.count("c_1"), 1)
+        self.assertEqual(res.count("c_2"), 1)
+
 
 class RenderFieldTagUseTemplateVariableTest(TestCase):
     def test_use_template_variable_in_parametrs(self):


### PR DESCRIPTION
Updated runtests to support new django 1.10 config.